### PR TITLE
fixes theos not having changed the description for twisted construction after nerfing it

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -177,7 +177,7 @@
 
 /datum/action/innate/cult/blood_spell/construction
 	name = "Twisted Construction"
-	desc = "Empowers your hand to corrupt certain metalic objects.<br><u>Converts:</u><br>Plasteel into runed metal<br>50 metal into a construct shell<br>Living cyborgs into constructs after a delay<br>Cyborg shells into construct shells<br>Airlocks into brittle runed airlocks after a delay (harm intent)"
+	desc = "Empowers your hand to corrupt certain metalic objects.<br><u>Converts:</u><br>Plasteel into runed metal<br>50 metal into a construct shell<br>Airlocks into brittle runed airlocks after a delay (harm intent)"
 	button_icon_state = "transmute"
 	magic_path = "/obj/item/melee/blood_magic/construction"
 	health_cost = 12


### PR DESCRIPTION
changes the description to not mention converting shells or borgs because it cant lmao

# Wiki Documentation

the blood cultist wikipage incorrectly states that twisted construction can convert cyborgs as well, fix it??

# Changelog

:cl:  
spellcheck: cult's twisted construction no longer incorrectly states that it can convert cyborgs
experimental: fixes a theos moment
/:cl:
